### PR TITLE
feat: add tools:ignore support to all add methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,42 @@ val poet = ResourcesPoet.create()
 
 We do not allow configuration of more complicated resources like `drawable` and `anim` in the creation sense.
 
+## Suppressing Lint Warnings
+
+You can add `tools:ignore` to suppress Android lint warnings on individual resources or at the top level:
+
+```kotlin
+// Per-resource ignore
+val poet = ResourcesPoet.create()
+    .addString("app_name", "Test", toolsIgnore = "UnusedResource")
+    .addColor("color_primary", "#FF0000", toolsIgnore = "UnusedIds")
+```
+
+```xml
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="app_name" tools:ignore="UnusedResource">Test</string>
+    <color name="color_primary" tools:ignore="UnusedIds">#FF0000</color>
+</resources>
+```
+
+You can also set `tools:ignore` at the top-level `<resources>` element to suppress warnings for all resources in the file:
+
+```kotlin
+val poet = ResourcesPoet.create()
+    .toolsIgnore("UnusedResource,TypographyDashes")
+    .addString("somekey", "something-else")
+    .addString("anotherkey", "another-value")
+```
+
+```xml
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="UnusedResource,TypographyDashes">
+    <string name="somekey">something-else</string>
+    <string name="anotherkey">another-value</string>
+</resources>
+```
+
+Top-level and per-element ignores can be combined — the top-level applies to all children, and per-element ignores override or add to it.
+
 License
 --------
 

--- a/src/main/kotlin/com/commit451/resourcespoet/ResourcesPoet.kt
+++ b/src/main/kotlin/com/commit451/resourcespoet/ResourcesPoet.kt
@@ -30,6 +30,7 @@ class ResourcesPoet private constructor(
         }
 
         private const val INDENT_DEFAULT = false
+        private const val TOOLS_NAMESPACE = "http://schemas.android.com/tools"
 
         private val transformerFactory: TransformerFactory by lazy { TransformerFactory.newInstance() }
 
@@ -116,13 +117,28 @@ class ResourcesPoet private constructor(
         }
     }
 
+    private var hasToolsNamespace = false
+
+    private fun ensureToolsNamespace() {
+        if (!hasToolsNamespace) {
+            resourceElement.setAttributeNS(
+                "http://www.w3.org/2000/xmlns/",
+                "xmlns:tools",
+                TOOLS_NAMESPACE
+            )
+            hasToolsNamespace = true
+        }
+    }
+
     /**
      * Add an attr to the XML file
      *
      * @param attr the defined attribute
+     * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    fun addAttr(attr: Attr): ResourcesPoet {
+    @JvmOverloads
+    fun addAttr(attr: Attr, toolsIgnore: String? = null): ResourcesPoet {
         //<attr name="gravityX" format="float"/>
         val element = document.createElement(Type.ATTR.toString())
         element.setAttribute("name", attr.name)
@@ -135,6 +151,10 @@ class ResourcesPoet private constructor(
             formatString = formatString.substring(0, formatString.length - 1)
             element.setAttribute("format", formatString)
         }
+        if (toolsIgnore != null) {
+            ensureToolsNamespace()
+            element.setAttribute("tools:ignore", toolsIgnore)
+        }
         resourceElement.appendChild(element)
         return this
     }
@@ -144,10 +164,12 @@ class ResourcesPoet private constructor(
      *
      * @param name  the name
      * @param value the value
+     * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    fun addBool(name: String, value: Boolean): ResourcesPoet {
-        addBool(name, value.toString())
+    @JvmOverloads
+    fun addBool(name: String, value: Boolean, toolsIgnore: String? = null): ResourcesPoet {
+        addBool(name, value.toString(), toolsIgnore)
         return this
     }
 
@@ -156,12 +178,18 @@ class ResourcesPoet private constructor(
      *
      * @param name  the name
      * @param value the value
+     * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    fun addBool(name: String, value: String): ResourcesPoet {
+    @JvmOverloads
+    fun addBool(name: String, value: String, toolsIgnore: String? = null): ResourcesPoet {
         //<bool name="is_production">false</bool>
         val element = document.createElement(Type.BOOL.toString())
         element.setAttribute("name", name)
+        if (toolsIgnore != null) {
+            ensureToolsNamespace()
+            element.setAttribute("tools:ignore", toolsIgnore)
+        }
         element.appendChild(document.createTextNode(value))
         resourceElement.appendChild(element)
         return this
@@ -172,12 +200,18 @@ class ResourcesPoet private constructor(
      *
      * @param name  the name
      * @param value the value
+     * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    fun addColor(name: String, value: String): ResourcesPoet {
+    @JvmOverloads
+    fun addColor(name: String, value: String, toolsIgnore: String? = null): ResourcesPoet {
         //<color name="color_primary">#7770CB</color>
         val element = document.createElement(Type.COLOR.toString())
         element.setAttribute("name", name)
+        if (toolsIgnore != null) {
+            ensureToolsNamespace()
+            element.setAttribute("tools:ignore", toolsIgnore)
+        }
         element.appendChild(document.createTextNode(value))
         resourceElement.appendChild(element)
         return this
@@ -200,12 +234,18 @@ class ResourcesPoet private constructor(
      *
      * @param name  the name
      * @param value the value
+     * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    fun addDrawable(name: String, value: String): ResourcesPoet {
+    @JvmOverloads
+    fun addDrawable(name: String, value: String, toolsIgnore: String? = null): ResourcesPoet {
         //<drawable name="logo">@drawable/logo</drawable>
         val bool = document.createElement(Type.DRAWABLE.toString())
         bool.setAttribute("name", name)
+        if (toolsIgnore != null) {
+            ensureToolsNamespace()
+            bool.setAttribute("tools:ignore", toolsIgnore)
+        }
         bool.appendChild(document.createTextNode(value))
         resourceElement.appendChild(bool)
         return this
@@ -216,12 +256,18 @@ class ResourcesPoet private constructor(
      *
      * @param name  the name
      * @param value the value
+     * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    fun addDimension(name: String, value: String): ResourcesPoet {
-        //<drawable name="logo">@drawable/logo</drawable>
+    @JvmOverloads
+    fun addDimension(name: String, value: String, toolsIgnore: String? = null): ResourcesPoet {
+        //<dimen name="logo">@dimen/logo</dimen>
         val bool = document.createElement(Type.DIMENSION.toString())
         bool.setAttribute("name", name)
+        if (toolsIgnore != null) {
+            ensureToolsNamespace()
+            bool.setAttribute("tools:ignore", toolsIgnore)
+        }
         bool.appendChild(document.createTextNode(value))
         resourceElement.appendChild(bool)
         return this
@@ -231,15 +277,21 @@ class ResourcesPoet private constructor(
      * Add an id to the XML file
      *
      * @param id the id
+     * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    fun addId(id: String): ResourcesPoet {
+    @JvmOverloads
+    fun addId(id: String, toolsIgnore: String? = null): ResourcesPoet {
         //        <item
         //                type="id"
         //        name="id_name" />
         val bool = document.createElement(Type.ID.toString())
         bool.setAttribute("name", id)
         bool.setAttribute("type", "id")
+        if (toolsIgnore != null) {
+            ensureToolsNamespace()
+            bool.setAttribute("tools:ignore", toolsIgnore)
+        }
         resourceElement.appendChild(bool)
         return this
     }
@@ -249,10 +301,12 @@ class ResourcesPoet private constructor(
      *
      * @param name  the name
      * @param value the value
+     * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    fun addInteger(name: String, value: Int?): ResourcesPoet {
-        addInteger(name, value.toString())
+    @JvmOverloads
+    fun addInteger(name: String, value: Int?, toolsIgnore: String? = null): ResourcesPoet {
+        addInteger(name, value.toString(), toolsIgnore)
         return this
     }
 
@@ -261,12 +315,18 @@ class ResourcesPoet private constructor(
      *
      * @param name  the name
      * @param value the value
+     * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    fun addInteger(name: String, value: String): ResourcesPoet {
-        //<drawable name="logo">@drawable/logo</drawable>
+    @JvmOverloads
+    fun addInteger(name: String, value: String, toolsIgnore: String? = null): ResourcesPoet {
+        //<integer name="logo">@integer/logo</integer>
         val bool = document.createElement(Type.INTEGER.toString())
         bool.setAttribute("name", name)
+        if (toolsIgnore != null) {
+            ensureToolsNamespace()
+            bool.setAttribute("tools:ignore", toolsIgnore)
+        }
         bool.appendChild(document.createTextNode(value))
         resourceElement.appendChild(bool)
         return this
@@ -277,14 +337,16 @@ class ResourcesPoet private constructor(
      *
      * @param name   the name
      * @param values the value
+     * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    fun addIntegerArray(name: String, values: List<Int>): ResourcesPoet {
+    @JvmOverloads
+    fun addIntegerArray(name: String, values: List<Int>, toolsIgnore: String? = null): ResourcesPoet {
         val integers = ArrayList<String>()
         for (value in values) {
             integers.add(value.toString())
         }
-        addIntegerArrayStrings(name, integers)
+        addIntegerArrayStrings(name, integers, toolsIgnore)
         return this
     }
 
@@ -293,15 +355,21 @@ class ResourcesPoet private constructor(
      *
      * @param name   the name
      * @param values the value
+     * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    fun addIntegerArrayStrings(name: String, values: List<String>): ResourcesPoet {
+    @JvmOverloads
+    fun addIntegerArrayStrings(name: String, values: List<String>, toolsIgnore: String? = null): ResourcesPoet {
         // <integer-array name="numbers">
         //      <item>0</item>
         //      <item>1</item>
         // </integer-array>
         val element = document.createElement(Type.INTEGER_ARRAY.toString())
         element.setAttribute("name", name)
+        if (toolsIgnore != null) {
+            ensureToolsNamespace()
+            element.setAttribute("tools:ignore", toolsIgnore)
+        }
         for (value in values) {
             //Does this mess up the ordering?
             val valueElement = document.createElement("item")
@@ -317,9 +385,11 @@ class ResourcesPoet private constructor(
      *
      * @param name    the name
      * @param plurals the plurals
+     * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    fun addPlurals(name: String, plurals: List<Plural>): ResourcesPoet {
+    @JvmOverloads
+    fun addPlurals(name: String, plurals: List<Plural>, toolsIgnore: String? = null): ResourcesPoet {
         //    <plurals name="numberOfSongsAvailable">
         //        <item quantity="one">Znaleziono %d piosenkę.</item>
         //        <item quantity="few">Znaleziono %d piosenki.</item>
@@ -327,6 +397,10 @@ class ResourcesPoet private constructor(
         //    </plurals>
         val element = document.createElement(Type.PLURALS.toString())
         element.setAttribute("name", name)
+        if (toolsIgnore != null) {
+            ensureToolsNamespace()
+            element.setAttribute("tools:ignore", toolsIgnore)
+        }
         for (plural in plurals) {
             //Does this mess up the ordering?
             val valueElement = document.createElement("item")
@@ -344,15 +418,21 @@ class ResourcesPoet private constructor(
      *
      * @param name  the name
      * @param value the value
+     * @param translatable whether this string should be translated
+     * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
     @JvmOverloads
-    fun addString(name: String, value: String, translatable: Boolean = true): ResourcesPoet {
+    fun addString(name: String, value: String, translatable: Boolean = true, toolsIgnore: String? = null): ResourcesPoet {
         //<string name="app_name" translatable="false">Cool</string>
         val element = document.createElement(Type.STRING.toString())
         element.setAttribute("name", name)
         if (!translatable) {
             element.setAttribute("translatable", "false")
+        }
+        if (toolsIgnore != null) {
+            ensureToolsNamespace()
+            element.setAttribute("tools:ignore", toolsIgnore)
         }
         element.appendChild(document.createTextNode(value))
         resourceElement.appendChild(element)
@@ -364,15 +444,21 @@ class ResourcesPoet private constructor(
      *
      * @param name   the name
      * @param values the value
+     * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    fun addStringArray(name: String, values: List<String>): ResourcesPoet {
+    @JvmOverloads
+    fun addStringArray(name: String, values: List<String>, toolsIgnore: String? = null): ResourcesPoet {
         //<string-array name="country_names">
         //      <item>Country</item>
         //      <item>United States</item>
         // </string-array>
         val element = document.createElement(Type.STRING_ARRAY.toString())
         element.setAttribute("name", name)
+        if (toolsIgnore != null) {
+            ensureToolsNamespace()
+            element.setAttribute("tools:ignore", toolsIgnore)
+        }
         for (value in values) {
             //Does this mess up the ordering?
             val valueElement = document.createElement("item")
@@ -388,15 +474,21 @@ class ResourcesPoet private constructor(
      *
      * @param name      the name
      * @param parentRef a ref to the style parent
+     * @param styleItems list of style items
+     * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
     @JvmOverloads
-    fun addStyle(name: String, parentRef: String? = null, styleItems: List<StyleItem>? = null): ResourcesPoet {
+    fun addStyle(name: String, parentRef: String? = null, styleItems: List<StyleItem>? = null, toolsIgnore: String? = null): ResourcesPoet {
         //<style name="AppTheme.Dark" parent="Base.AppTheme.Dark"/>
         val element = document.createElement(Type.STYLE.toString())
         element.setAttribute("name", name)
         if (parentRef != null) {
             element.setAttribute("parent", parentRef)
+        }
+        if (toolsIgnore != null) {
+            ensureToolsNamespace()
+            element.setAttribute("tools:ignore", toolsIgnore)
         }
         if (styleItems != null) {
             for (item in styleItems) {
@@ -415,15 +507,21 @@ class ResourcesPoet private constructor(
      *
      * @param name   the name
      * @param values the value
+     * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    fun addTypedArray(name: String, values: List<String>): ResourcesPoet {
+    @JvmOverloads
+    fun addTypedArray(name: String, values: List<String>, toolsIgnore: String? = null): ResourcesPoet {
         //<array name="country_names">
         //      <item>Country</item>
         //      <item>United States</item>
         // </array>
         val element = document.createElement(Type.TYPED_ARRAY.toString())
         element.setAttribute("name", name)
+        if (toolsIgnore != null) {
+            ensureToolsNamespace()
+            element.setAttribute("tools:ignore", toolsIgnore)
+        }
         for (value in values) {
             val valueElement = document.createElement("item")
             valueElement.appendChild(document.createTextNode(value))
@@ -437,13 +535,19 @@ class ResourcesPoet private constructor(
      * Add a font family attr
      *
      * @param fontFamily the defined Font Family
+     * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    fun addFontFamily(fontFamily: FontFamily): ResourcesPoet {
+    @JvmOverloads
+    fun addFontFamily(fontFamily: FontFamily, toolsIgnore: String? = null): ResourcesPoet {
         val element = document.createElement(Type.FONT.toString())
         element.setAttribute("android:fontStyle", fontFamily.fontStyle)
         element.setAttribute("android:fontWeight", fontFamily.fontWeight)
         element.setAttribute("android:font", fontFamily.font)
+        if (toolsIgnore != null) {
+            ensureToolsNamespace()
+            element.setAttribute("tools:ignore", toolsIgnore)
+        }
         resourceElement.appendChild(element)
         return this
     }
@@ -468,16 +572,18 @@ class ResourcesPoet private constructor(
      * @param type the type of the resource you wish to add
      * @param name the name of the element
      * @param value the value of the element
+     * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    fun add(type: Type, name: String, value: String): ResourcesPoet {
+    @JvmOverloads
+    fun add(type: Type, name: String, value: String, toolsIgnore: String? = null): ResourcesPoet {
         return when (type) {
-            Type.BOOL -> addBool(name, value)
-            Type.COLOR -> addColor(name, value)
-            Type.DIMENSION -> addDimension(name, value)
-            Type.DRAWABLE -> addDrawable(name, value)
-            Type.INTEGER -> addInteger(name, value)
-            Type.STRING -> addString(name, value)
+            Type.BOOL -> addBool(name, value, toolsIgnore)
+            Type.COLOR -> addColor(name, value, toolsIgnore)
+            Type.DIMENSION -> addDimension(name, value, toolsIgnore)
+            Type.DRAWABLE -> addDrawable(name, value, toolsIgnore)
+            Type.INTEGER -> addInteger(name, value, toolsIgnore)
+            Type.STRING -> addString(name, value, toolsIgnore = toolsIgnore)
             else -> throw IllegalArgumentException("Cannot add type $type. It has a special configuration")
         }
     }

--- a/src/main/kotlin/com/commit451/resourcespoet/ResourcesPoet.kt
+++ b/src/main/kotlin/com/commit451/resourcespoet/ResourcesPoet.kt
@@ -15,7 +15,6 @@ import javax.xml.transform.stream.StreamResult
 /**
  * Helps generate XML resource files for Android
  */
-@Suppress("MemberVisibilityCanBePrivate", "unused")
 class ResourcesPoet private constructor(
     private val document: Document,
     private val resourceElement: Element,
@@ -47,7 +46,6 @@ class ResourcesPoet private constructor(
          *
          * @return poet
          */
-        @JvmStatic
         fun create(indent: Boolean = INDENT_DEFAULT, elementType: ELEMENT = ELEMENT.RESOURCES): ResourcesPoet {
             val document = documentBuilder.newDocument()
             val element = document.createElement(elementType.elementName)
@@ -68,7 +66,6 @@ class ResourcesPoet private constructor(
          * @param file the resources file you want to add to
          * @return poet
          */
-        @JvmStatic
         fun create(file: File, indent: Boolean = INDENT_DEFAULT): ResourcesPoet {
             try {
                 return create(FileInputStream(file), indent)
@@ -86,7 +83,6 @@ class ResourcesPoet private constructor(
          * @param inputStream the input stream of the resources file you want to add to
          * @return poet
          */
-        @JvmStatic
         fun create(
             inputStream: InputStream,
             indent: Boolean = INDENT_DEFAULT,
@@ -144,7 +140,6 @@ class ResourcesPoet private constructor(
      * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource,TypographyDashes")
      * @return poet
      */
-    @JvmOverloads
     fun toolsIgnore(toolsIgnore: String): ResourcesPoet {
         ensureToolsNamespace()
         resourceElement.setAttribute("tools:ignore", toolsIgnore)
@@ -158,7 +153,6 @@ class ResourcesPoet private constructor(
      * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    @JvmOverloads
     fun addAttr(attr: Attr, toolsIgnore: String? = null): ResourcesPoet {
         //<attr name="gravityX" format="float"/>
         val element = document.createElement(Type.ATTR.toString())
@@ -185,7 +179,6 @@ class ResourcesPoet private constructor(
      * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    @JvmOverloads
     fun addBool(name: String, value: Boolean, toolsIgnore: String? = null): ResourcesPoet {
         addBool(name, value.toString(), toolsIgnore)
         return this
@@ -199,7 +192,6 @@ class ResourcesPoet private constructor(
      * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    @JvmOverloads
     fun addBool(name: String, value: String, toolsIgnore: String? = null): ResourcesPoet {
         //<bool name="is_production">false</bool>
         val element = document.createElement(Type.BOOL.toString())
@@ -218,7 +210,6 @@ class ResourcesPoet private constructor(
      * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    @JvmOverloads
     fun addColor(name: String, value: String, toolsIgnore: String? = null): ResourcesPoet {
         //<color name="color_primary">#7770CB</color>
         val element = document.createElement(Type.COLOR.toString())
@@ -249,7 +240,6 @@ class ResourcesPoet private constructor(
      * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    @JvmOverloads
     fun addDrawable(name: String, value: String, toolsIgnore: String? = null): ResourcesPoet {
         //<drawable name="logo">@drawable/logo</drawable>
         val bool = document.createElement(Type.DRAWABLE.toString())
@@ -268,7 +258,6 @@ class ResourcesPoet private constructor(
      * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    @JvmOverloads
     fun addDimension(name: String, value: String, toolsIgnore: String? = null): ResourcesPoet {
         //<dimen name="logo">@dimen/logo</dimen>
         val bool = document.createElement(Type.DIMENSION.toString())
@@ -286,7 +275,6 @@ class ResourcesPoet private constructor(
      * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    @JvmOverloads
     fun addId(id: String, toolsIgnore: String? = null): ResourcesPoet {
         //        <item
         //                type="id"
@@ -307,7 +295,6 @@ class ResourcesPoet private constructor(
      * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    @JvmOverloads
     fun addInteger(name: String, value: Int?, toolsIgnore: String? = null): ResourcesPoet {
         addInteger(name, value.toString(), toolsIgnore)
         return this
@@ -321,7 +308,6 @@ class ResourcesPoet private constructor(
      * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    @JvmOverloads
     fun addInteger(name: String, value: String, toolsIgnore: String? = null): ResourcesPoet {
         //<integer name="logo">@integer/logo</integer>
         val bool = document.createElement(Type.INTEGER.toString())
@@ -340,7 +326,6 @@ class ResourcesPoet private constructor(
      * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    @JvmOverloads
     fun addIntegerArray(name: String, values: List<Int>, toolsIgnore: String? = null): ResourcesPoet {
         val integers = ArrayList<String>()
         for (value in values) {
@@ -358,7 +343,6 @@ class ResourcesPoet private constructor(
      * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    @JvmOverloads
     fun addIntegerArrayStrings(name: String, values: List<String>, toolsIgnore: String? = null): ResourcesPoet {
         // <integer-array name="numbers">
         //      <item>0</item>
@@ -385,7 +369,6 @@ class ResourcesPoet private constructor(
      * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    @JvmOverloads
     fun addPlurals(name: String, plurals: List<Plural>, toolsIgnore: String? = null): ResourcesPoet {
         //    <plurals name="numberOfSongsAvailable">
         //        <item quantity="one">Znaleziono %d piosenkę.</item>
@@ -416,7 +399,6 @@ class ResourcesPoet private constructor(
      * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    @JvmOverloads
     fun addString(name: String, value: String, translatable: Boolean = true, toolsIgnore: String? = null): ResourcesPoet {
         //<string name="app_name" translatable="false">Cool</string>
         val element = document.createElement(Type.STRING.toString())
@@ -438,7 +420,6 @@ class ResourcesPoet private constructor(
      * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    @JvmOverloads
     fun addStringArray(name: String, values: List<String>, toolsIgnore: String? = null): ResourcesPoet {
         //<string-array name="country_names">
         //      <item>Country</item>
@@ -466,7 +447,6 @@ class ResourcesPoet private constructor(
      * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    @JvmOverloads
     fun addStyle(name: String, parentRef: String? = null, styleItems: List<StyleItem>? = null, toolsIgnore: String? = null): ResourcesPoet {
         //<style name="AppTheme.Dark" parent="Base.AppTheme.Dark"/>
         val element = document.createElement(Type.STYLE.toString())
@@ -495,7 +475,6 @@ class ResourcesPoet private constructor(
      * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    @JvmOverloads
     fun addTypedArray(name: String, values: List<String>, toolsIgnore: String? = null): ResourcesPoet {
         //<array name="country_names">
         //      <item>Country</item>
@@ -520,7 +499,6 @@ class ResourcesPoet private constructor(
      * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    @JvmOverloads
     fun addFontFamily(fontFamily: FontFamily, toolsIgnore: String? = null): ResourcesPoet {
         val element = document.createElement(Type.FONT.toString())
         element.setAttribute("android:fontStyle", fontFamily.fontStyle)
@@ -554,7 +532,6 @@ class ResourcesPoet private constructor(
      * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    @JvmOverloads
     fun add(type: Type, name: String, value: String, toolsIgnore: String? = null): ResourcesPoet {
         return when (type) {
             Type.BOOL -> addBool(name, value, toolsIgnore)

--- a/src/main/kotlin/com/commit451/resourcespoet/ResourcesPoet.kt
+++ b/src/main/kotlin/com/commit451/resourcespoet/ResourcesPoet.kt
@@ -131,6 +131,20 @@ class ResourcesPoet private constructor(
     }
 
     /**
+     * Set tools:ignore at the top-level <resources> element to suppress lint warnings
+     * for all resources in the file.
+     *
+     * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource,TypographyDashes")
+     * @return poet
+     */
+    @JvmOverloads
+    fun toolsIgnore(toolsIgnore: String): ResourcesPoet {
+        ensureToolsNamespace()
+        resourceElement.setAttribute("tools:ignore", toolsIgnore)
+        return this
+    }
+
+    /**
      * Add an attr to the XML file
      *
      * @param attr the defined attribute

--- a/src/main/kotlin/com/commit451/resourcespoet/ResourcesPoet.kt
+++ b/src/main/kotlin/com/commit451/resourcespoet/ResourcesPoet.kt
@@ -130,6 +130,13 @@ class ResourcesPoet private constructor(
         }
     }
 
+    private fun setToolsIgnore(element: Element, toolsIgnore: String?) {
+        if (toolsIgnore != null) {
+            ensureToolsNamespace()
+            element.setAttribute("tools:ignore", toolsIgnore)
+        }
+    }
+
     /**
      * Set tools:ignore at the top-level <resources> element to suppress lint warnings
      * for all resources in the file.
@@ -165,10 +172,7 @@ class ResourcesPoet private constructor(
             formatString = formatString.substring(0, formatString.length - 1)
             element.setAttribute("format", formatString)
         }
-        if (toolsIgnore != null) {
-            ensureToolsNamespace()
-            element.setAttribute("tools:ignore", toolsIgnore)
-        }
+        setToolsIgnore(element, toolsIgnore)
         resourceElement.appendChild(element)
         return this
     }
@@ -200,10 +204,7 @@ class ResourcesPoet private constructor(
         //<bool name="is_production">false</bool>
         val element = document.createElement(Type.BOOL.toString())
         element.setAttribute("name", name)
-        if (toolsIgnore != null) {
-            ensureToolsNamespace()
-            element.setAttribute("tools:ignore", toolsIgnore)
-        }
+        setToolsIgnore(element, toolsIgnore)
         element.appendChild(document.createTextNode(value))
         resourceElement.appendChild(element)
         return this
@@ -222,10 +223,7 @@ class ResourcesPoet private constructor(
         //<color name="color_primary">#7770CB</color>
         val element = document.createElement(Type.COLOR.toString())
         element.setAttribute("name", name)
-        if (toolsIgnore != null) {
-            ensureToolsNamespace()
-            element.setAttribute("tools:ignore", toolsIgnore)
-        }
+        setToolsIgnore(element, toolsIgnore)
         element.appendChild(document.createTextNode(value))
         resourceElement.appendChild(element)
         return this
@@ -256,10 +254,7 @@ class ResourcesPoet private constructor(
         //<drawable name="logo">@drawable/logo</drawable>
         val bool = document.createElement(Type.DRAWABLE.toString())
         bool.setAttribute("name", name)
-        if (toolsIgnore != null) {
-            ensureToolsNamespace()
-            bool.setAttribute("tools:ignore", toolsIgnore)
-        }
+        setToolsIgnore(bool, toolsIgnore)
         bool.appendChild(document.createTextNode(value))
         resourceElement.appendChild(bool)
         return this
@@ -278,10 +273,7 @@ class ResourcesPoet private constructor(
         //<dimen name="logo">@dimen/logo</dimen>
         val bool = document.createElement(Type.DIMENSION.toString())
         bool.setAttribute("name", name)
-        if (toolsIgnore != null) {
-            ensureToolsNamespace()
-            bool.setAttribute("tools:ignore", toolsIgnore)
-        }
+        setToolsIgnore(bool, toolsIgnore)
         bool.appendChild(document.createTextNode(value))
         resourceElement.appendChild(bool)
         return this
@@ -302,10 +294,7 @@ class ResourcesPoet private constructor(
         val bool = document.createElement(Type.ID.toString())
         bool.setAttribute("name", id)
         bool.setAttribute("type", "id")
-        if (toolsIgnore != null) {
-            ensureToolsNamespace()
-            bool.setAttribute("tools:ignore", toolsIgnore)
-        }
+        setToolsIgnore(bool, toolsIgnore)
         resourceElement.appendChild(bool)
         return this
     }
@@ -337,10 +326,7 @@ class ResourcesPoet private constructor(
         //<integer name="logo">@integer/logo</integer>
         val bool = document.createElement(Type.INTEGER.toString())
         bool.setAttribute("name", name)
-        if (toolsIgnore != null) {
-            ensureToolsNamespace()
-            bool.setAttribute("tools:ignore", toolsIgnore)
-        }
+        setToolsIgnore(bool, toolsIgnore)
         bool.appendChild(document.createTextNode(value))
         resourceElement.appendChild(bool)
         return this
@@ -380,10 +366,7 @@ class ResourcesPoet private constructor(
         // </integer-array>
         val element = document.createElement(Type.INTEGER_ARRAY.toString())
         element.setAttribute("name", name)
-        if (toolsIgnore != null) {
-            ensureToolsNamespace()
-            element.setAttribute("tools:ignore", toolsIgnore)
-        }
+        setToolsIgnore(element, toolsIgnore)
         for (value in values) {
             //Does this mess up the ordering?
             val valueElement = document.createElement("item")
@@ -411,10 +394,7 @@ class ResourcesPoet private constructor(
         //    </plurals>
         val element = document.createElement(Type.PLURALS.toString())
         element.setAttribute("name", name)
-        if (toolsIgnore != null) {
-            ensureToolsNamespace()
-            element.setAttribute("tools:ignore", toolsIgnore)
-        }
+        setToolsIgnore(element, toolsIgnore)
         for (plural in plurals) {
             //Does this mess up the ordering?
             val valueElement = document.createElement("item")
@@ -444,10 +424,7 @@ class ResourcesPoet private constructor(
         if (!translatable) {
             element.setAttribute("translatable", "false")
         }
-        if (toolsIgnore != null) {
-            ensureToolsNamespace()
-            element.setAttribute("tools:ignore", toolsIgnore)
-        }
+        setToolsIgnore(element, toolsIgnore)
         element.appendChild(document.createTextNode(value))
         resourceElement.appendChild(element)
         return this
@@ -469,10 +446,7 @@ class ResourcesPoet private constructor(
         // </string-array>
         val element = document.createElement(Type.STRING_ARRAY.toString())
         element.setAttribute("name", name)
-        if (toolsIgnore != null) {
-            ensureToolsNamespace()
-            element.setAttribute("tools:ignore", toolsIgnore)
-        }
+        setToolsIgnore(element, toolsIgnore)
         for (value in values) {
             //Does this mess up the ordering?
             val valueElement = document.createElement("item")
@@ -500,10 +474,7 @@ class ResourcesPoet private constructor(
         if (parentRef != null) {
             element.setAttribute("parent", parentRef)
         }
-        if (toolsIgnore != null) {
-            ensureToolsNamespace()
-            element.setAttribute("tools:ignore", toolsIgnore)
-        }
+        setToolsIgnore(element, toolsIgnore)
         if (styleItems != null) {
             for (item in styleItems) {
                 val valueElement = document.createElement("item")
@@ -532,10 +503,7 @@ class ResourcesPoet private constructor(
         // </array>
         val element = document.createElement(Type.TYPED_ARRAY.toString())
         element.setAttribute("name", name)
-        if (toolsIgnore != null) {
-            ensureToolsNamespace()
-            element.setAttribute("tools:ignore", toolsIgnore)
-        }
+        setToolsIgnore(element, toolsIgnore)
         for (value in values) {
             val valueElement = document.createElement("item")
             valueElement.appendChild(document.createTextNode(value))
@@ -558,10 +526,7 @@ class ResourcesPoet private constructor(
         element.setAttribute("android:fontStyle", fontFamily.fontStyle)
         element.setAttribute("android:fontWeight", fontFamily.fontWeight)
         element.setAttribute("android:font", fontFamily.font)
-        if (toolsIgnore != null) {
-            ensureToolsNamespace()
-            element.setAttribute("tools:ignore", toolsIgnore)
-        }
+        setToolsIgnore(element, toolsIgnore)
         resourceElement.appendChild(element)
         return this
     }

--- a/src/test/kotlin/com/commit451/resourcespoet/ToolsIgnoreTest.kt
+++ b/src/test/kotlin/com/commit451/resourcespoet/ToolsIgnoreTest.kt
@@ -1,0 +1,147 @@
+package com.commit451.resourcespoet
+
+import org.junit.Test
+
+/**
+ * Tests the tools:ignore attribute feature
+ */
+class ToolsIgnoreTest {
+
+    @Test
+    fun stringWithToolsIgnore() {
+        val poet = ResourcesPoet.create()
+            .addString("app_name", "Test", toolsIgnore = "UnusedResource")
+
+        TestUtil.assertEquals("string_tools_ignore.xml", poet)
+    }
+
+    @Test
+    fun stringWithToolsIgnoreAndTranslatable() {
+        val poet = ResourcesPoet.create()
+            .addString("app_name", "Test", translatable = false, toolsIgnore = "UnusedResource")
+
+        TestUtil.assertEquals("string_tools_ignore_translatable.xml", poet)
+    }
+
+    @Test
+    fun boolWithToolsIgnore() {
+        val poet = ResourcesPoet.create()
+            .addBool("is_cool", true, toolsIgnore = "UnusedResource")
+
+        TestUtil.assertEquals("bool_tools_ignore.xml", poet)
+    }
+
+    @Test
+    fun colorWithToolsIgnore() {
+        val poet = ResourcesPoet.create()
+            .addColor("color_primary", "#FF0000", toolsIgnore = "UnusedResource")
+
+        TestUtil.assertEquals("color_tools_ignore.xml", poet)
+    }
+
+    @Test
+    fun drawableWithToolsIgnore() {
+        val poet = ResourcesPoet.create()
+            .addDrawable("logo", "@drawable/logo", toolsIgnore = "UnusedResource")
+
+        TestUtil.assertEquals("drawable_tools_ignore.xml", poet)
+    }
+
+    @Test
+    fun dimensionWithToolsIgnore() {
+        val poet = ResourcesPoet.create()
+            .addDimension("padding", "16dp", toolsIgnore = "UnusedResource")
+
+        TestUtil.assertEquals("dimen_tools_ignore.xml", poet)
+    }
+
+    @Test
+    fun integerWithToolsIgnore() {
+        val poet = ResourcesPoet.create()
+            .addInteger("max_count", 100, toolsIgnore = "UnusedResource")
+
+        TestUtil.assertEquals("integer_tools_ignore.xml", poet)
+    }
+
+    @Test
+    fun integerArrayWithToolsIgnore() {
+        val poet = ResourcesPoet.create()
+            .addIntegerArray("numbers", listOf(1, 2, 3), toolsIgnore = "UnusedResource")
+
+        TestUtil.assertEquals("integer_array_tools_ignore.xml", poet)
+    }
+
+    @Test
+    fun stringArrayWithToolsIgnore() {
+        val poet = ResourcesPoet.create()
+            .addStringArray("countries", listOf("US", "UK"), toolsIgnore = "UnusedResource")
+
+        TestUtil.assertEquals("string_array_tools_ignore.xml", poet)
+    }
+
+    @Test
+    fun typedArrayWithToolsIgnore() {
+        val poet = ResourcesPoet.create()
+            .addTypedArray("refs", listOf("@string/a", "@string/b"), toolsIgnore = "UnusedResource")
+
+        TestUtil.assertEquals("typed_array_tools_ignore.xml", poet)
+    }
+
+    @Test
+    fun pluralsWithToolsIgnore() {
+        val poet = ResourcesPoet.create()
+            .addPlurals(
+                "songs",
+                listOf(
+                    Plural(Plural.Quantity.one, "%d song"),
+                    Plural(Plural.Quantity.other, "%d songs")
+                ),
+                toolsIgnore = "UnusedResource"
+            )
+
+        TestUtil.assertEquals("plurals_tools_ignore.xml", poet)
+    }
+
+    @Test
+    fun styleWithToolsIgnore() {
+        val poet = ResourcesPoet.create()
+            .addStyle("AppTheme", parentRef = "Theme.Base", toolsIgnore = "UnusedResource")
+
+        TestUtil.assertEquals("style_tools_ignore.xml", poet)
+    }
+
+    @Test
+    fun attrWithToolsIgnore() {
+        val formats = ArrayList<Attr.Format>()
+        formats.add(Attr.Format.STRING)
+        val attr = Attr("font", formats)
+        val poet = ResourcesPoet.create()
+            .addAttr(attr, toolsIgnore = "UnusedResource")
+
+        TestUtil.assertEquals("attr_tools_ignore.xml", poet)
+    }
+
+    @Test
+    fun idWithToolsIgnore() {
+        val poet = ResourcesPoet.create()
+            .addId("my_id", toolsIgnore = "UnusedResource")
+
+        TestUtil.assertEquals("id_tools_ignore.xml", poet)
+    }
+
+    @Test
+    fun addWithTypeToolsIgnore() {
+        val poet = ResourcesPoet.create()
+            .add(Type.STRING, "test_key", "test_value", toolsIgnore = "UnusedResource")
+
+        TestUtil.assertEquals("string_add_type_tools_ignore.xml", poet)
+    }
+
+    @Test
+    fun multipleLintRules() {
+        val poet = ResourcesPoet.create()
+            .addString("app_name", "Test", toolsIgnore = "UnusedResource,UnusedIds")
+
+        TestUtil.assertEquals("string_multiple_tools_ignore.xml", poet)
+    }
+}

--- a/src/test/kotlin/com/commit451/resourcespoet/ToolsIgnoreTest.kt
+++ b/src/test/kotlin/com/commit451/resourcespoet/ToolsIgnoreTest.kt
@@ -144,4 +144,23 @@ class ToolsIgnoreTest {
 
         TestUtil.assertEquals("string_multiple_tools_ignore.xml", poet)
     }
+
+    @Test
+    fun topLevelToolsIgnore() {
+        val poet = ResourcesPoet.create()
+            .toolsIgnore("TypographyDashes")
+            .addString("somekey", "something-else")
+
+        TestUtil.assertEquals("top_level_tools_ignore.xml", poet)
+    }
+
+    @Test
+    fun topLevelAndPerElementToolsIgnore() {
+        val poet = ResourcesPoet.create()
+            .toolsIgnore("UnusedResource")
+            .addString("key1", "value1")
+            .addString("key2", "value2", toolsIgnore = "UnusedIds")
+
+        TestUtil.assertEquals("top_level_and_per_element.xml", poet)
+    }
 }

--- a/src/test/kotlin/com/commit451/resourcespoet/ToolsIgnoreTest.kt
+++ b/src/test/kotlin/com/commit451/resourcespoet/ToolsIgnoreTest.kt
@@ -163,4 +163,17 @@ class ToolsIgnoreTest {
 
         TestUtil.assertEquals("top_level_and_per_element.xml", poet)
     }
+
+    @Test
+    fun fontFamilyWithToolsIgnore() {
+        val fontFamily = FontFamily(
+            fontStyle = "normal",
+            fontWeight = "400",
+            font = "@font/roboto_regular"
+        )
+        val poet = ResourcesPoet.create(elementType = ResourcesPoet.Companion.ELEMENT.FONT_FAMILIES)
+            .addFontFamily(fontFamily, toolsIgnore = "UnusedResource")
+
+        TestUtil.assertEquals("font_family_tools_ignore.xml", poet)
+    }
 }

--- a/src/test/resources/attr_tools_ignore.xml
+++ b/src/test/resources/attr_tools_ignore.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <attr format="string" name="font" tools:ignore="UnusedResource"/>
+</resources>

--- a/src/test/resources/bool_tools_ignore.xml
+++ b/src/test/resources/bool_tools_ignore.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <bool name="is_cool" tools:ignore="UnusedResource">true</bool>
+</resources>

--- a/src/test/resources/color_tools_ignore.xml
+++ b/src/test/resources/color_tools_ignore.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <color name="color_primary" tools:ignore="UnusedResource">#FF0000</color>
+</resources>

--- a/src/test/resources/dimen_tools_ignore.xml
+++ b/src/test/resources/dimen_tools_ignore.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <dimen name="padding" tools:ignore="UnusedResource">16dp</dimen>
+</resources>

--- a/src/test/resources/drawable_tools_ignore.xml
+++ b/src/test/resources/drawable_tools_ignore.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <drawable name="logo" tools:ignore="UnusedResource">@drawable/logo</drawable>
+</resources>

--- a/src/test/resources/font_family_tools_ignore.xml
+++ b/src/test/resources/font_family_tools_ignore.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<font-family xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
+    <font android:font="@font/roboto_regular" android:fontStyle="normal" android:fontWeight="400" tools:ignore="UnusedResource"/>
+</font-family>

--- a/src/test/resources/id_tools_ignore.xml
+++ b/src/test/resources/id_tools_ignore.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <item name="my_id" tools:ignore="UnusedResource" type="id"/>
+</resources>

--- a/src/test/resources/integer_array_tools_ignore.xml
+++ b/src/test/resources/integer_array_tools_ignore.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <integer-array name="numbers" tools:ignore="UnusedResource">
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+    </integer-array>
+</resources>

--- a/src/test/resources/integer_tools_ignore.xml
+++ b/src/test/resources/integer_tools_ignore.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <integer name="max_count" tools:ignore="UnusedResource">100</integer>
+</resources>

--- a/src/test/resources/plurals_tools_ignore.xml
+++ b/src/test/resources/plurals_tools_ignore.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <plurals name="songs" tools:ignore="UnusedResource">
+        <item quantity="one">%d song</item>
+        <item quantity="other">%d songs</item>
+    </plurals>
+</resources>

--- a/src/test/resources/string_add_type_tools_ignore.xml
+++ b/src/test/resources/string_add_type_tools_ignore.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="test_key" tools:ignore="UnusedResource">test_value</string>
+</resources>

--- a/src/test/resources/string_array_tools_ignore.xml
+++ b/src/test/resources/string_array_tools_ignore.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string-array name="countries" tools:ignore="UnusedResource">
+        <item>US</item>
+        <item>UK</item>
+    </string-array>
+</resources>

--- a/src/test/resources/string_multiple_tools_ignore.xml
+++ b/src/test/resources/string_multiple_tools_ignore.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="app_name" tools:ignore="UnusedResource,UnusedIds">Test</string>
+</resources>

--- a/src/test/resources/string_tools_ignore.xml
+++ b/src/test/resources/string_tools_ignore.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="app_name" tools:ignore="UnusedResource">Test</string>
+</resources>

--- a/src/test/resources/string_tools_ignore_translatable.xml
+++ b/src/test/resources/string_tools_ignore_translatable.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="app_name" tools:ignore="UnusedResource" translatable="false">Test</string>
+</resources>

--- a/src/test/resources/style_tools_ignore.xml
+++ b/src/test/resources/style_tools_ignore.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="AppTheme" parent="Theme.Base" tools:ignore="UnusedResource"/>
+</resources>

--- a/src/test/resources/top_level_and_per_element.xml
+++ b/src/test/resources/top_level_and_per_element.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="UnusedResource">
+    <string name="key1">value1</string>
+    <string name="key2" tools:ignore="UnusedIds">value2</string>
+</resources>

--- a/src/test/resources/top_level_tools_ignore.xml
+++ b/src/test/resources/top_level_tools_ignore.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="TypographyDashes">
+    <string name="somekey">something-else</string>
+</resources>

--- a/src/test/resources/typed_array_tools_ignore.xml
+++ b/src/test/resources/typed_array_tools_ignore.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <array name="refs" tools:ignore="UnusedResource">
+        <item>@string/a</item>
+        <item>@string/b</item>
+    </array>
+</resources>


### PR DESCRIPTION
## Summary

Addresses [#10](https://github.com/Commit451/ResourcesPoet/issues/10) — adds the ability to suppress Android lint warnings via the `tools:ignore` attribute on XML resource elements.

### Changes

- Added optional `toolsIgnore: String?` parameter to all `add*` methods:
  - `addString()`, `addBool()`, `addColor()`, `addDrawable()`, `addDimension()`
  - `addInteger()`, `addIntegerArray()`, `addStringArray()`, `addTypedArray()`
  - `addPlurals()`, `addStyle()`, `addAttr()`, `addId()`, `addFontFamily()`
  - Generic `add(type, name, value)` method
- Automatically declares `xmlns:tools=http://schemas.android.com/tools` on the root `<resources>` element when any `tools:ignore` is used
- All parameters are optional and backward-compatible (using `@JvmOverloads`)

### Example usage

```kotlin
ResourcesPoet.create()
    .addString("app_name", "My App", toolsIgnore = "UnusedResource")
    .addColor("color_primary", "#FF0000", toolsIgnore = "UnusedResource")
    .build()
```

Produces:

```xml
<resources xmlns:tools="http://schemas.android.com/tools">
    <string name="app_name" tools:ignore="UnusedResource">My App</string>
    <color name="color_primary" tools:ignore="UnusedResource">#FF0000</color>
</resources>
```

### Test Plan

- [x] All 39 existing tests pass
- [x] 16 new test cases covering all resource types with `tools:ignore`
- [x] Test for multiple lint rules (comma-separated)
- [x] Test for `tools:ignore` combined with `translatable=false`