### PR TITLE
chore: update GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate Gradle Wrapper
         uses: gradle/actions/wrapper-validation@v4
 
       - name: Configure JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: '21'

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: '21'


### PR DESCRIPTION
## What

Update deprecated GitHub Actions versions to support Node.js 24 (default by June 16, 2026):

- `actions/checkout`: `v4` → `v6`
- `actions/setup-java`: `v4` → `v5`

## Why

Node.js 20 is deprecated on GitHub Actions runners and will be removed on September 16, 2026. These newer action versions support Node.js 24.