### PR TITLE
feat: add comment attribute support to addString

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,19 @@ val poet = ResourcesPoet.create()
 
 Top-level and per-element ignores can be combined — the top-level applies to all children, and per-element ignores override or add to it.
 
+## Adding Resource Comments
+
+You can add a `comment` attribute to `<string>` elements. This comment is displayed in Android Studio's resource inspector, making it easier for translators and developers to understand the purpose of each string:
+
+```kotlin
+val poet = ResourcesPoet.create()
+    .addString("dialog_close_button", "Close", comment = "Button to dismiss the dialog")
+```
+
+```xml
+<string comment="Button to dismiss the dialog" name="dialog_close_button">Close</string>
+```
+
 License
 --------
 

--- a/src/main/kotlin/com/commit451/resourcespoet/ResourcesPoet.kt
+++ b/src/main/kotlin/com/commit451/resourcespoet/ResourcesPoet.kt
@@ -396,15 +396,19 @@ class ResourcesPoet private constructor(
      * @param name  the name
      * @param value the value
      * @param translatable whether this string should be translated
+     * @param comment comment for the string (shown in Android Studio resource inspector)
      * @param toolsIgnore lint rule names to suppress (e.g., "UnusedResource")
      * @return poet
      */
-    fun addString(name: String, value: String, translatable: Boolean = true, toolsIgnore: String? = null): ResourcesPoet {
-        //<string name="app_name" translatable="false">Cool</string>
+    fun addString(name: String, value: String, translatable: Boolean = true, comment: String? = null, toolsIgnore: String? = null): ResourcesPoet {
+        //<string name="app_name" translatable="false" comment="...">Cool</string>
         val element = document.createElement(Type.STRING.toString())
         element.setAttribute("name", name)
         if (!translatable) {
             element.setAttribute("translatable", "false")
+        }
+        if (comment != null) {
+            element.setAttribute("comment", comment)
         }
         setToolsIgnore(element, toolsIgnore)
         element.appendChild(document.createTextNode(value))

--- a/src/test/kotlin/com/commit451/resourcespoet/StringTest.kt
+++ b/src/test/kotlin/com/commit451/resourcespoet/StringTest.kt
@@ -22,4 +22,12 @@ class StringTest {
 
         TestUtil.assertEquals("string_translatable_false.xml", poet)
     }
+
+    @Test
+    fun stringCommentTest() {
+        val poet = ResourcesPoet.create()
+            .addString("dialog_close_button", "Close", comment = "Button to dismiss the dialog")
+
+        TestUtil.assertEquals("string_comment.xml", poet)
+    }
 }

--- a/src/test/resources/string_comment.xml
+++ b/src/test/resources/string_comment.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<resources>
+    <string comment="Button to dismiss the dialog" name="dialog_close_button">Close</string>
+</resources>


### PR DESCRIPTION
## What

Add optional `comment` parameter to `addString()` that sets the Android `comment` attribute on `<string>` elements.

## Example

```kotlin
ResourcesPoet.create()
    .addString("dialog_close_button", "Close", comment = "Button to dismiss the dialog")
```

Outputs:
```xml
<string comment="Button to dismiss the dialog" name="dialog_close_button">Close</string>
```

## Why

The `comment` attribute is displayed in Android Studio's resource inspector, making it easier for translators and developers to understand the purpose of each string.